### PR TITLE
Spanish translation of the contracts

### DIFF
--- a/Spanish/README.md
+++ b/Spanish/README.md
@@ -80,7 +80,7 @@ Este proyecto puede mejorarse y va a evolucionar a medida que StarkNet madure. �
 
 Los puntos son distribuidos por la función `distribute_points()` mientras la función `validate_exercise` registra que haz completado el ejercicio (puedes obtener puntos solo una vez). Tu objetivo es:
 
-![Graph](assets/diagram.png)
+![Graph](../assets/diagram.png)
 ​
 
 ### Usando Voyager

--- a/Spanish/contracts/ex01.cairo
+++ b/Spanish/contracts/ex01.cairo
@@ -1,0 +1,59 @@
+// Ejercicio 01
+// Usando una función de contrato público simple
+// En este ejercicio, necesita:
+// - Usar la función claim_points() de este contrato
+// - Sus puntos son acreditados por el contrato
+
+// Lo que aprenderás
+// - Sintaxis general del contrato inteligente
+// - Llamar a una función
+
+// -----
+// GENERAL DIRECTIVES AND IMPORTS
+// -----
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+from contracts.utils.ex00_base import (
+    tderc20_address,
+    has_validated_exercise,
+    distribute_points,
+    validate_exercise,
+    ex_initializer,
+)
+
+// -----
+// CONSTRUCTOR
+// -----
+// Esta función se llama cuando se implementa el contrato
+//
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    _tderc20_address: felt, _players_registry: felt, _workshop_id: felt, _exercise_id: felt
+) {
+    ex_initializer(_tderc20_address, _players_registry, _workshop_id, _exercise_id);
+    return ();
+}
+
+// -----
+// EXTERNAL FUNCTIONS
+// -----
+// Estas funciones pueden ser llamadas por otros contratos.
+//
+
+// Esta función se llama claim_points
+// Guarda en (sender_address) un felt. Lea más sobre felts aquí https://www.cairo-lang.org/docs/hello_cairo/intro.htmlfield-element
+// Tiene argumentos implícitos (syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr). Lea más sobre argumentos implícitos aquí https://www.cairo-lang.org/docs/how_cairo_works/builtins.html
+@external
+func claim_points{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    // Reading caller address
+    let (sender_address) = get_caller_address();
+    // Checking if the user has validated the exercise before
+    validate_exercise(sender_address);
+    // Sending points to the address specified as parameter
+    distribute_points(sender_address, 2);
+    return ();
+}

--- a/Spanish/contracts/token/ERC20_base.cairo
+++ b/Spanish/contracts/token/ERC20_base.cairo
@@ -1,0 +1,238 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_add,
+    uint256_sub,
+    uint256_le,
+    uint256_lt,
+    uint256_check,
+)
+
+//
+// Storage
+//
+
+@storage_var
+func ERC20_name_() -> (name: felt) {
+}
+
+@storage_var
+func ERC20_symbol_() -> (symbol: felt) {
+}
+
+@storage_var
+func ERC20_decimals_() -> (decimals: felt) {
+}
+
+@storage_var
+func ERC20_total_supply() -> (total_supply: Uint256) {
+}
+
+@storage_var
+func ERC20_balances(account: felt) -> (balance: Uint256) {
+}
+
+@storage_var
+func ERC20_allowances(owner: felt, spender: felt) -> (allowance: Uint256) {
+}
+
+//
+// Constructor
+//
+
+func ERC20_initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, initial_supply: Uint256, recipient: felt
+) {
+    ERC20_name_.write(name);
+    ERC20_symbol_.write(symbol);
+    ERC20_decimals_.write(18);
+    ERC20_mint(recipient, initial_supply);
+    return ();
+}
+
+func ERC20_name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    let (name) = ERC20_name_.read();
+    return (name,);
+}
+
+func ERC20_symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    symbol: felt
+) {
+    let (symbol) = ERC20_symbol_.read();
+    return (symbol,);
+}
+
+func ERC20_totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20_total_supply.read();
+    return (totalSupply,);
+}
+
+func ERC20_decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    let (decimals) = ERC20_decimals_.read();
+    return (decimals,);
+}
+
+func ERC20_balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) -> (balance: Uint256) {
+    let (balance: Uint256) = ERC20_balances.read(account);
+    return (balance,);
+}
+
+func ERC20_allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    let (remaining: Uint256) = ERC20_allowances.read(owner, spender);
+    return (remaining,);
+}
+
+func ERC20_transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) {
+    let (sender) = get_caller_address();
+    _transfer(sender, recipient, amount);
+    return ();
+}
+
+func ERC20_transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> () {
+    alloc_locals;
+    let (local caller) = get_caller_address();
+    let (local caller_allowance: Uint256) = ERC20_allowances.read(owner=sender, spender=caller);
+
+    // validates amount <= caller_allowance and returns 1 if true
+    let (enough_allowance) = uint256_le(amount, caller_allowance);
+    assert_not_zero(enough_allowance);
+
+    _transfer(sender, recipient, amount);
+
+    // subtract allowance
+    let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount);
+    ERC20_allowances.write(sender, caller, new_allowance);
+    return ();
+}
+
+func ERC20_approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) {
+    let (caller) = get_caller_address();
+    assert_not_zero(caller);
+    assert_not_zero(spender);
+    uint256_check(amount);
+    ERC20_allowances.write(caller, spender, amount);
+    return ();
+}
+
+func ERC20_increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> () {
+    alloc_locals;
+    uint256_check(added_value);
+    let (local caller) = get_caller_address();
+    let (local current_allowance: Uint256) = ERC20_allowances.read(caller, spender);
+
+    // add allowance
+    let (local new_allowance: Uint256, is_overflow) = uint256_add(current_allowance, added_value);
+    assert (is_overflow) = 0;
+
+    ERC20_approve(spender, new_allowance);
+    return ();
+}
+
+func ERC20_decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> () {
+    alloc_locals;
+    uint256_check(subtracted_value);
+    let (local caller) = get_caller_address();
+    let (local current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender);
+    let (local new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value);
+
+    // validates new_allowance < current_allowance and returns 1 if true
+    let (enough_allowance) = uint256_lt(new_allowance, current_allowance);
+    assert_not_zero(enough_allowance);
+
+    ERC20_approve(spender, new_allowance);
+    return ();
+}
+
+func ERC20_mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) {
+    alloc_locals;
+    assert_not_zero(recipient);
+    uint256_check(amount);
+
+    let (balance: Uint256) = ERC20_balances.read(account=recipient);
+    // overflow is not possible because sum is guaranteed to be less than total supply
+    // which we check for overflow below
+    let (new_balance, _: Uint256) = uint256_add(balance, amount);
+    ERC20_balances.write(recipient, new_balance);
+
+    let (local supply: Uint256) = ERC20_total_supply.read();
+    let (local new_supply: Uint256, is_overflow) = uint256_add(supply, amount);
+    assert (is_overflow) = 0;
+
+    ERC20_total_supply.write(new_supply);
+    return ();
+}
+
+func ERC20_burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, amount: Uint256
+) {
+    alloc_locals;
+    assert_not_zero(account);
+    uint256_check(amount);
+
+    let (balance: Uint256) = ERC20_balances.read(account);
+    // validates amount <= balance and returns 1 if true
+    let (enough_balance) = uint256_le(amount, balance);
+    assert_not_zero(enough_balance);
+
+    let (new_balance: Uint256) = uint256_sub(balance, amount);
+    ERC20_balances.write(account, new_balance);
+
+    let (supply: Uint256) = ERC20_total_supply.read();
+    let (new_supply: Uint256) = uint256_sub(supply, amount);
+    ERC20_total_supply.write(new_supply);
+    return ();
+}
+
+//
+// Internal
+//
+
+func _transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) {
+    alloc_locals;
+    assert_not_zero(sender);
+    assert_not_zero(recipient);
+    uint256_check(amount);  // almost surely not needed, might remove after confirmation
+
+    let (local sender_balance: Uint256) = ERC20_balances.read(account=sender);
+
+    // validates amount <= sender_balance and returns 1 if true
+    let (enough_balance) = uint256_le(amount, sender_balance);
+    assert_not_zero(enough_balance);
+
+    // subtract from sender
+    let (new_sender_balance: Uint256) = uint256_sub(sender_balance, amount);
+    ERC20_balances.write(sender, new_sender_balance);
+
+    // add to recipient
+    let (recipient_balance: Uint256) = ERC20_balances.read(account=recipient);
+    // overflow is not possible because sum is guaranteed by mint to be less than total supply
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, amount);
+    ERC20_balances.write(recipient, new_recipient_balance);
+    return ();
+}

--- a/Spanish/contracts/token/IERC20.cairo
+++ b/Spanish/contracts/token/IERC20.cairo
@@ -1,0 +1,33 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC20 {
+    func name() -> (name: felt) {
+    }
+
+    func symbol() -> (symbol: felt) {
+    }
+
+    func decimals() -> (decimals: felt) {
+    }
+
+    func totalSupply() -> (totalSupply: Uint256) {
+    }
+
+    func balanceOf(account: felt) -> (balance: Uint256) {
+    }
+
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256) {
+    }
+
+    func transfer(recipient: felt, amount: Uint256) -> (success: felt) {
+    }
+
+    func transferFrom(sender: felt, recipient: felt, amount: Uint256) -> (success: felt) {
+    }
+
+    func approve(spender: felt, amount: Uint256) -> (success: felt) {
+    }
+}

--- a/Spanish/contracts/token/ITDERC20.cairo
+++ b/Spanish/contracts/token/ITDERC20.cairo
@@ -1,0 +1,24 @@
+%lang starknet
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_add,
+    uint256_sub,
+    uint256_le,
+    uint256_lt,
+    uint256_check,
+)
+@contract_interface
+namespace ITDERC20 {
+    func distribute_points(to: felt, amount: Uint256) {
+    }
+    func remove_points(to: felt, amount: Uint256) {
+    }
+    func set_teacher(account: felt, permission: felt) {
+    }
+    func is_teacher_or_exercise(account: felt) -> (permission: felt) {
+    }
+    func set_teachers_temp(accounts_len: felt, accounts: felt*) {
+    }
+    func set_teacher_temp(account: felt) {
+    }
+}

--- a/Spanish/contracts/token/TDERC20.cairo
+++ b/Spanish/contracts/token/TDERC20.cairo
@@ -1,0 +1,236 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.starknet.common.syscalls import get_caller_address
+
+from contracts.token.ERC20_base import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+    ERC20_mint,
+    ERC20_burn,
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+)
+
+@storage_var
+func teachers_and_exercises_accounts(account: felt) -> (balance: felt) {
+}
+
+@storage_var
+func is_transferable_storage() -> (is_transferable_storage: felt) {
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, initial_supply: Uint256, recipient: felt, owner: felt
+) {
+    ERC20_initializer(name, symbol, initial_supply, recipient);
+    teachers_and_exercises_accounts.write(owner, 1);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func is_transferable{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    is_transferable: felt
+) {
+    let (is_transferable) = is_transferable_storage.read();
+    return (is_transferable,);
+}
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    let (name) = ERC20_name();
+    return (name,);
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    let (symbol) = ERC20_symbol();
+    return (symbol,);
+}
+
+@view
+func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20_totalSupply();
+    return (totalSupply,);
+}
+
+@view
+func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    let (decimals) = ERC20_decimals();
+    return (decimals,);
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
+    balance: Uint256
+) {
+    let (balance: Uint256) = ERC20_balanceOf(account);
+    return (balance,);
+}
+
+@view
+func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    let (remaining: Uint256) = ERC20_allowance(owner, spender);
+    return (remaining,);
+}
+
+//
+// Externals
+//
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    _is_transferable();
+    ERC20_transfer(recipient, amount);
+    // Cairo equivalent to 'return (true)'
+    return (1,);
+}
+
+@external
+func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> (success: felt) {
+    _is_transferable();
+    ERC20_transferFrom(sender, recipient, amount);
+    // Cairo equivalent to 'return (true)'
+    return (1,);
+}
+
+@external
+func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) -> (success: felt) {
+    ERC20_approve(spender, amount);
+    // Cairo equivalent to 'return (true)'
+    return (1,);
+}
+
+@external
+func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> (success: felt) {
+    ERC20_increaseAllowance(spender, added_value);
+    // Cairo equivalent to 'return (true)'
+    return (1,);
+}
+
+@external
+func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> (success: felt) {
+    ERC20_decreaseAllowance(spender, subtracted_value);
+    // Cairo equivalent to 'return (true)'
+    return (1,);
+}
+
+@external
+func distribute_points{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: Uint256
+) {
+    only_teacher_or_exercise();
+    ERC20_mint(to, amount);
+    return ();
+}
+
+@external
+func remove_points{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: Uint256
+) {
+    only_teacher_or_exercise();
+    ERC20_burn(to, amount);
+    return ();
+}
+
+@external
+func set_teacher{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, permission: felt
+) {
+    only_teacher_or_exercise();
+    teachers_and_exercises_accounts.write(account, permission);
+
+    return ();
+}
+
+@external
+func set_teachers{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    accounts_len: felt, accounts: felt*
+) {
+    only_teacher_or_exercise();
+    _set_teacher(accounts_len, accounts);
+    return ();
+}
+
+@external
+func set_transferable{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    permission: felt
+) {
+    only_teacher_or_exercise();
+    _set_transferable(permission);
+    return ();
+}
+
+@view
+func is_teacher_or_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) -> (permission: felt) {
+    let (permission: felt) = teachers_and_exercises_accounts.read(account);
+    return (permission,);
+}
+
+func _set_teacher{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    accounts_len: felt, accounts: felt*
+) {
+    if (accounts_len == 0) {
+        // Start with sum=0.
+        return ();
+    }
+
+    // If length is NOT zero, then the function calls itself again, by moving forward one slot
+    _set_teacher(accounts_len=accounts_len - 1, accounts=accounts + 1);
+
+    // This part of the function is first reached when length=0.
+    teachers_and_exercises_accounts.write([accounts], 1);
+    return ();
+}
+
+func only_teacher_or_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (caller) = get_caller_address();
+    let (permission) = teachers_and_exercises_accounts.read(account=caller);
+    assert permission = 1;
+    return ();
+}
+
+func _is_transferable{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (permission) = is_transferable_storage.read();
+    assert permission = 1;
+    return ();
+}
+
+func _set_transferable{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    permission: felt
+) {
+    is_transferable_storage.write(permission);
+    return ();
+}

--- a/Spanish/contracts/utils/IAccountContract.cairo
+++ b/Spanish/contracts/utils/IAccountContract.cairo
@@ -1,0 +1,11 @@
+%lang starknet
+
+//###################
+// INTERFACE
+//###################
+
+@contract_interface
+namespace IAccountContract {
+    func get_signer() -> (signer: felt) {
+    }
+}

--- a/Spanish/contracts/utils/Iex10.cairo
+++ b/Spanish/contracts/utils/Iex10.cairo
@@ -1,0 +1,13 @@
+%lang starknet
+
+//###################
+// INTERFACE
+//###################
+
+@contract_interface
+namespace Iex10 {
+    func set_ex_10b_address(ex_10b_address_: felt) {
+    }
+    func has_validated_exercise(account: felt) -> (has_validated_exercise: felt) {
+    }
+}

--- a/Spanish/contracts/utils/Iex10b.cairo
+++ b/Spanish/contracts/utils/Iex10b.cairo
@@ -1,0 +1,13 @@
+%lang starknet
+
+//###################
+// INTERFACE
+//###################
+
+@contract_interface
+namespace Iex10b {
+    func secret_value() -> (secret_value: felt) {
+    }
+    func change_secret_value(new_secret_value: felt) {
+    }
+}

--- a/Spanish/contracts/utils/Iplayers_registry.cairo
+++ b/Spanish/contracts/utils/Iplayers_registry.cairo
@@ -1,0 +1,27 @@
+%lang starknet
+
+//###################
+// INTERFACE
+//###################
+
+@contract_interface
+namespace Iplayers_registry {
+    func has_validated_exercise(account: felt, workshop: felt, exercise: felt) -> (
+        has_validated_exercise: felt
+    ) {
+    }
+    func is_exercise_or_admin(account: felt) -> (permission: felt) {
+    }
+    func next_player_rank() -> (next_player_rank: felt) {
+    }
+    func players_registry(rank: felt) -> (account: felt) {
+    }
+    func player_ranks(account: felt) -> (rank: felt) {
+    }
+    func set_exercise_or_admin(account: felt, permission: felt) {
+    }
+    func set_exercises_or_admins(accounts_len: felt, accounts: felt*) {
+    }
+    func validate_exercise(account: felt, workshop: felt, exercise: felt) {
+    }
+}

--- a/Spanish/contracts/utils/ex00_base.cairo
+++ b/Spanish/contracts/utils/ex00_base.cairo
@@ -1,0 +1,153 @@
+// ######## Ex 00
+// # A contract from which other contracts can import functions
+
+%lang starknet
+
+from contracts.token.ITDERC20 import ITDERC20
+from contracts.utils.Iplayers_registry import Iplayers_registry
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_add,
+    uint256_sub,
+    uint256_le,
+    uint256_lt,
+    uint256_check,
+)
+from starkware.cairo.common.math import assert_not_zero
+from starkware.starknet.common.syscalls import get_contract_address
+//
+// Declaring storage vars
+// Storage vars are by default not visible through the ABI. They are similar to "private" variables in Solidity
+//
+
+@storage_var
+func tderc20_address_storage() -> (tderc20_address_storage: felt) {
+}
+
+@storage_var
+func players_registry_storage() -> (tderc20_address_storage: felt) {
+}
+
+@storage_var
+func workshop_id_storage() -> (workshop_id_storage: felt) {
+}
+
+@storage_var
+func exercise_id_storage() -> (exercise_id_storage: felt) {
+}
+//
+// Declaring getters
+// Public variables should be declared explicitely with a getter
+//
+
+@view
+func tderc20_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _tderc20_address: felt
+) {
+    let (_tderc20_address) = tderc20_address_storage.read();
+    return (_tderc20_address,);
+}
+
+@view
+func players_registry{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _players_registry: felt
+) {
+    let (_players_registry) = players_registry_storage.read();
+    return (_players_registry,);
+}
+
+@view
+func workshop_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _workshop_id: felt
+) {
+    let (_workshop_id) = workshop_id_storage.read();
+    return (_workshop_id,);
+}
+
+@view
+func exercise_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _exercise_id: felt
+) {
+    let (_exercise_id) = exercise_id_storage.read();
+    return (_exercise_id,);
+}
+
+@view
+func has_validated_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) -> (has_validated_exercise: felt) {
+    // reading player registry
+    let (_players_registry) = players_registry_storage.read();
+    let (_workshop_id) = workshop_id_storage.read();
+    let (_exercise_id) = exercise_id_storage.read();
+    // Checking if the user already validated this exercise
+    let (has_current_user_validated_exercise) = Iplayers_registry.has_validated_exercise(
+        contract_address=_players_registry,
+        account=account,
+        workshop=_workshop_id,
+        exercise=_exercise_id,
+    );
+    return (has_current_user_validated_exercise,);
+}
+
+//
+// Internal constructor
+// This function is used to initialize the contract. It can be called from the constructor
+//
+
+func ex_initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    _tderc20_address: felt, _players_registry: felt, _workshop_id: felt, _exercise_id: felt
+) {
+    tderc20_address_storage.write(_tderc20_address);
+    players_registry_storage.write(_players_registry);
+    workshop_id_storage.write(_workshop_id);
+    exercise_id_storage.write(_exercise_id);
+    return ();
+}
+
+//
+// Internal functions
+// These functions can not be called directly by a transaction
+// Similar to internal functions in Solidity
+//
+
+func distribute_points{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: felt
+) {
+    // Converting felt to uint256. We assume it's a small number
+    // We also add the required number of decimals
+    let points_to_credit: Uint256 = Uint256(amount * 1000000000000000000, 0);
+    // Retrieving contract address from storage
+    let (contract_address) = tderc20_address_storage.read();
+    // Calling the ERC20 contract to distribute points
+    ITDERC20.distribute_points(contract_address=contract_address, to=to, amount=points_to_credit);
+    return ();
+}
+
+func validate_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) {
+    // reading player registry
+    let (_players_registry) = players_registry_storage.read();
+    let (_workshop_id) = workshop_id_storage.read();
+    let (_exercise_id) = exercise_id_storage.read();
+    // Checking if the user already validated this exercise
+    let (has_current_user_validated_exercise) = Iplayers_registry.has_validated_exercise(
+        contract_address=_players_registry,
+        account=account,
+        workshop=_workshop_id,
+        exercise=_exercise_id,
+    );
+    assert (has_current_user_validated_exercise) = 0;
+
+    // Marking the exercise as completed
+    Iplayers_registry.validate_exercise(
+        contract_address=_players_registry,
+        account=account,
+        workshop=_workshop_id,
+        exercise=_exercise_id,
+    );
+
+    return ();
+}

--- a/Spanish/contracts/utils/ex11_base.cairo
+++ b/Spanish/contracts/utils/ex11_base.cairo
@@ -1,0 +1,207 @@
+// ######## Ex 00
+// # A contract from which other contracts can import functions
+
+%lang starknet
+
+from contracts.token.ITDERC20 import ITDERC20
+from contracts.utils.Iplayers_registry import Iplayers_registry
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_add,
+    uint256_sub,
+    uint256_le,
+    uint256_lt,
+    uint256_check,
+)
+from starkware.cairo.common.math import assert_not_zero
+from starkware.starknet.common.syscalls import get_contract_address
+
+//
+// Declaring storage vars
+// Storage vars are by default not visible through the ABI. They are similar to "private" variables in Solidity
+//
+
+@storage_var
+func tderc20_address_storage() -> (tderc20_address_storage: felt) {
+}
+
+@storage_var
+func players_registry_storage() -> (tderc20_address_storage: felt) {
+}
+
+@storage_var
+func workshop_id_storage() -> (workshop_id_storage: felt) {
+}
+
+@storage_var
+func exercise_id_storage() -> (exercise_id_storage: felt) {
+}
+//
+@storage_var
+func ex11_secret_value() -> (secret_value: felt) {
+}
+
+//
+// Declaring getters
+// Public variables should be declared explicitly with a getter
+//
+
+@view
+func tderc20_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _tderc20_address: felt
+) {
+    let (_tderc20_address) = tderc20_address_storage.read();
+    return (_tderc20_address,);
+}
+
+@view
+func players_registry{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _players_registry: felt
+) {
+    let (_players_registry) = players_registry_storage.read();
+    return (_players_registry,);
+}
+
+@view
+func workshop_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _workshop_id: felt
+) {
+    let (_workshop_id) = workshop_id_storage.read();
+    return (_workshop_id,);
+}
+
+@view
+func exercise_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    _exercise_id: felt
+) {
+    let (_exercise_id) = exercise_id_storage.read();
+    return (_exercise_id,);
+}
+
+@view
+func has_validated_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) -> (has_validated_exercise: felt) {
+    // reading player registry
+    let (_players_registry) = players_registry_storage.read();
+    let (_workshop_id) = workshop_id_storage.read();
+    let (_exercise_id) = exercise_id_storage.read();
+    // Checking if the user already validated this exercise
+    let (has_current_user_validated_exercise) = Iplayers_registry.has_validated_exercise(
+        contract_address=_players_registry,
+        account=account,
+        workshop=_workshop_id,
+        exercise=_exercise_id,
+    );
+    return (has_current_user_validated_exercise,);
+}
+
+@view
+func secret_value{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    secret_value: felt
+) {
+    let (secret_value) = ex11_secret_value.read();
+    // There is a trick here
+    return (secret_value + 42069,);
+}
+
+//
+// Internal constructor
+// This function is used to initialize the contract. It can be called from the constructor
+//
+
+func ex_initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    _tderc20_address: felt, _players_registry: felt, _workshop_id: felt, _exercise_id: felt
+) {
+    tderc20_address_storage.write(_tderc20_address);
+    players_registry_storage.write(_players_registry);
+    workshop_id_storage.write(_workshop_id);
+    exercise_id_storage.write(_exercise_id);
+    ex11_secret_value.write(_tderc20_address);
+    return ();
+}
+
+//
+// Internal functions
+// These functions can not be called directly by a transaction
+// Similar to internal functions in Solidity
+//
+
+func distribute_points{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: felt
+) {
+    // Converting felt to uint256. We assume it's a small number
+    // We also add the required number of decimals
+    let points_to_credit: Uint256 = Uint256(amount * 1000000000000000000, 0);
+    // Retrieving contract address from storage
+    let (contract_address) = tderc20_address_storage.read();
+    // Calling the ERC20 contract to distribute points
+    ITDERC20.distribute_points(contract_address=contract_address, to=to, amount=points_to_credit);
+    return ();
+}
+
+func validate_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) {
+    // reading player registry
+    let (_players_registry) = players_registry_storage.read();
+    let (_workshop_id) = workshop_id_storage.read();
+    let (_exercise_id) = exercise_id_storage.read();
+    // Checking if the user already validated this exercise
+    let (has_current_user_validated_exercise) = Iplayers_registry.has_validated_exercise(
+        contract_address=_players_registry,
+        account=account,
+        workshop=_workshop_id,
+        exercise=_exercise_id,
+    );
+    assert (has_current_user_validated_exercise) = 0;
+
+    // Marking the exercise as completed
+    Iplayers_registry.validate_exercise(
+        contract_address=_players_registry,
+        account=account,
+        workshop=_workshop_id,
+        exercise=_exercise_id,
+    );
+
+    return ();
+}
+
+func validate_answers{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender_address: felt, secret_value_i_guess: felt, next_secret_value_i_chose: felt
+) {
+    // CAREFUL THERE IS A TRAP FOR PEOPLE WHO WON'T READ THE CODE
+    // This exercise looks like the previous one, but actually the view secret_value returns a different value than secret_value
+    // Sending the wrong execution result will remove some of your points, then validate the exercise. You won't be able to get those points back later on!
+    alloc_locals;
+    let (secret_value) = ex11_secret_value.read();
+    local diff = secret_value_i_guess - secret_value;
+    // Laying our trap here
+    if (diff == 42069) {
+        // Converting felt to uint256. We assume it's a small number
+        // We also add the required number of decimals
+        let points_to_remove: Uint256 = Uint256(2 * 1000000000000000000, 0);
+        // # Retrieving contract address from storage
+        let (contract_address) = tderc20_address_storage.read();
+        // # Calling the ERC20 contract to distribute points
+        ITDERC20.remove_points(
+            contract_address=contract_address, to=sender_address, amount=points_to_remove
+        );
+        // This is necessary because of revoked references. Don't be scared, they won't stay around for too long...
+        return ();
+    } else {
+        // If secret value is correct, set new secret value
+        if (diff == 0) {
+            with_attr error_message("Chosen value can't be 0") {
+                assert_not_zero(next_secret_value_i_chose);
+            }
+            ex11_secret_value.write(next_secret_value_i_chose);
+            // This is necessary because of revoked references. Don't be scared, they won't stay around for too long...
+            return ();
+        } else {
+            assert 1 = 0;
+            return ();
+        }
+    }
+}

--- a/Spanish/contracts/utils/players_registry.cairo
+++ b/Spanish/contracts/utils/players_registry.cairo
@@ -1,0 +1,215 @@
+// ######## Players registry
+// # A contract to record all addresses who participated, and which exercises and workshops they completed
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_add,
+    uint256_sub,
+    uint256_le,
+    uint256_lt,
+    uint256_check,
+)
+from starkware.cairo.common.math import assert_not_zero
+from starkware.starknet.common.syscalls import get_caller_address
+//
+// Declaring storage vars
+// Storage vars are by default not visible through the ABI. They are similar to "private" variables in Solidity
+//
+
+@storage_var
+func has_validated_exercise_storage(account: felt, workshop: felt, exercise: felt) -> (
+    has_validated_exercise_storage: felt
+) {
+}
+
+@storage_var
+func exercises_and_admins_accounts(account: felt) -> (permission: felt) {
+}
+
+@storage_var
+func next_player_rank_storage() -> (next_player_rank_storage: felt) {
+}
+
+@storage_var
+func players_registry_storage(rank: felt) -> (account: felt) {
+}
+
+@storage_var
+func players_ranks_storage(account: felt) -> (rank: felt) {
+}
+
+//
+// Declaring getters
+// Public variables should be declared explicitely with a getter
+//
+
+@view
+func has_validated_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, workshop: felt, exercise: felt
+) -> (has_validated_exercise: felt) {
+    let (has_validated_exercise) = has_validated_exercise_storage.read(account, workshop, exercise);
+    return (has_validated_exercise,);
+}
+
+@view
+func is_exercise_or_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) -> (permission: felt) {
+    let (permission: felt) = exercises_and_admins_accounts.read(account);
+    return (permission,);
+}
+
+@view
+func next_player_rank{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    next_player_rank: felt
+) {
+    let (next_player_rank) = next_player_rank_storage.read();
+    return (next_player_rank,);
+}
+
+@view
+func players_registry{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    rank: felt
+) -> (account: felt) {
+    let (account) = players_registry_storage.read(rank);
+    return (account,);
+}
+
+@view
+func player_ranks{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt
+) -> (rank: felt) {
+    let (rank) = players_ranks_storage.read(account);
+    return (rank,);
+}
+
+//
+// Events
+// Keeping tracks of what happened
+//
+@event
+func modificate_exercise_or_admin(account: felt, permission: felt) {
+}
+
+@event
+func new_player(account: felt, rank: felt) {
+}
+
+@event
+func new_validation(account: felt, workshop: felt, exercise: felt) {
+}
+
+//
+// Internal constructor
+// This function is used to initialize the contract. It can be called from the constructor
+//
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    first_admin: felt
+) {
+    exercises_and_admins_accounts.write(first_admin, 1);
+    modificate_exercise_or_admin.emit(account=first_admin, permission=1);
+    next_player_rank_storage.write(1);
+    return ();
+}
+
+//
+// Internal functions
+// These functions can not be called directly by a transaction
+// Similar to internal functions in Solidity
+//
+
+func only_exercise_or_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (caller) = get_caller_address();
+    let (permission) = exercises_and_admins_accounts.read(account=caller);
+    assert permission = 1;
+    return ();
+}
+
+func _set_exercises_or_admins{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    accounts_len: felt, accounts: felt*
+) {
+    if (accounts_len == 0) {
+        // Start with sum=0.
+        return ();
+    }
+
+    // If length is NOT zero, then the function calls itself again, by moving forward one slot
+    _set_exercises_or_admins(accounts_len=accounts_len - 1, accounts=accounts + 1);
+
+    // This part of the function is first reached when length=0.
+    exercises_and_admins_accounts.write([accounts], 1);
+    modificate_exercise_or_admin.emit(account=[accounts], permission=1);
+
+    return ();
+}
+
+//
+// External functions
+//
+//
+//
+
+@external
+func set_exercise_or_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, permission: felt
+) {
+    only_exercise_or_admin();
+    exercises_and_admins_accounts.write(account, permission);
+    modificate_exercise_or_admin.emit(account=account, permission=permission);
+
+    return ();
+}
+
+@external
+func set_exercises_or_admins{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    accounts_len: felt, accounts: felt*
+) {
+    only_exercise_or_admin();
+    _set_exercises_or_admins(accounts_len, accounts);
+    return ();
+}
+
+@external
+func validate_exercise{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, workshop: felt, exercise: felt
+) {
+    only_exercise_or_admin();
+    // Checking if the user already validated this exercise
+    let (has_current_user_validated_exercise) = has_validated_exercise_storage.read(
+        account, workshop, exercise
+    );
+    with_attr error_message("User has already validated this exercise") {
+        assert (has_current_user_validated_exercise) = 0;
+    }
+
+    // Marking the exercise as completed
+    has_validated_exercise_storage.write(account, workshop, exercise, 1);
+    new_validation.emit(account=account, workshop=workshop, exercise=exercise);
+
+    // Recording player if he is not yet recorded
+    let (player_rank) = players_ranks_storage.read(account);
+
+    if (player_rank == 0) {
+        // Player is not yet record, let's record
+        let (next_player_rank) = next_player_rank_storage.read();
+        players_registry_storage.write(next_player_rank, account);
+        players_ranks_storage.write(account, next_player_rank);
+        let next_player_rank_plus_one = next_player_rank + 1;
+        next_player_rank_storage.write(next_player_rank_plus_one);
+        new_player.emit(account=account, rank=next_player_rank);
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+
+    return ();
+}


### PR DESCRIPTION
## Description
Translation to Spanish of contracts tutorials. This will allow the community to translate into a specific folder called `Spanish`. This could later be replicated in the Portuguese-speaking community.

## Actions
* Created the Spanish directory to store everything related to Spanish
* Translated the ex 01 contract.
* Moved `README.es.md` to `Spanish/README.md`.

## Who can review?
- @drspacemn @l-henri @LucasLvy @barretodavid  - does this structure makes sense to you?