### PR TITLE
Fix url link

### DIFF
--- a/contracts/ex01.cairo
+++ b/contracts/ex01.cairo
@@ -41,7 +41,7 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 //
 
 // This function is called claim_points
-// It takes one argument as a parameter (sender_address), which is a felt. Read more about felts here https://www.cairo-lang.org/docs/hello_cairo/intro.htmlfield-element
+// It takes one argument as a parameter (sender_address), which is a felt. Read more about felts here https://www.cairo-lang.org/docs/hello_cairo/intro.html#field-element
 // It also has implicit arguments (syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr). Read more about implicit arguments here https://www.cairo-lang.org/docs/how_cairo_works/builtins.html
 @external
 func claim_points{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {


### PR DESCRIPTION
https://www.cairo-lang.org/docs/hello_cairo/intro.htmlfield-element → [https://www.cairo-lang.org/docs/hello_cairo/intro.html#field-element](https://www.cairo-lang.org/docs/hello_cairo/intro.html#field-element)